### PR TITLE
Traverse over all workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ To use the plugin, add the following snippet to your Raito CLI configuration fil
    
    # SQL Warehouses (required for tag support, row-level filtering, and column masking)
    databricks-sql-warehouses:
-     <<deployment-id>>:
-       workspace: <<databricks workspace ID>>
+     - workspace: <<databricks workspace ID>>
+       warehouse: <<databricks SQL Warehouse ID>>
+     - workspace: <<databricks workspace ID>>
        warehouse: <<databricks SQL Warehouse ID>>
    
    # Native authentication

--- a/databricks/data_access_test.go
+++ b/databricks/data_access_test.go
@@ -98,7 +98,7 @@ func TestAccessSyncer_SyncAccessProvidersFromTarget(t *testing.T) {
 		},
 	}, nil).Once()
 
-	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Twice()
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().GetPermissionsOnResource(mock.Anything, catalog.SecurableTypeMetastore, "metastore-id1").Return(nil, nil).Once()
 
 	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{
@@ -535,7 +535,19 @@ func TestAccessSyncer_SyncAccessProviderToTarget(t *testing.T) {
 	mockAccountRepo.EXPECT().GetWorkspaces(mock.Anything).Return([]provisioning.Workspace{workspaceObject}, nil).Once()
 	mockAccountRepo.EXPECT().GetWorkspaceMap(mock.Anything, []catalog.MetastoreInfo{metastore1}, []provisioning.Workspace{workspaceObject}).Return(map[string][]*provisioning.Workspace{metastore1.MetastoreId: {{DeploymentName: deployment}}}, nil, nil).Once()
 
-	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Once()
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
+	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{
+		{
+			FullName:    "catalog-1",
+			MetastoreId: "catalogId-1",
+			Name:        "catalog-1",
+		},
+		{
+			FullName:    "catalog-2",
+			MetastoreId: "catalogId-2",
+			Name:        "catalog-2",
+		},
+	})).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SetPermissionsOnResource(mock.Anything, catalog.SecurableTypeCatalog, "catalog-1", mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, securableType catalog.SecurableType, s string, change ...catalog.PermissionsChange) error {
 		assert.Len(t, change, 3)
 
@@ -688,7 +700,7 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withMasks(t *testing.T) {
 			constants.DatabricksAccountId:     "AccountId",
 			constants.DatabricksUser:          "User",
 			constants.DatabricksPassword:      "Password",
-			constants.DatabricksSqlWarehouses: fmt.Sprintf(`{"metastore-id1": {"workspace": "%s", "warehouse": "sqlWarehouse1"}}`, deployment),
+			constants.DatabricksSqlWarehouses: fmt.Sprintf(`[{"workspace": "%s", "warehouse": "sqlWarehouse1"}]`, deployment),
 			constants.DatabricksPlatform:      "AWS",
 		},
 	}
@@ -711,6 +723,8 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withMasks(t *testing.T) {
 
 	mockWarehouseRepo := repo.NewMockWarehouseRepository(t)
 
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
+	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{{Name: "catalog-1", FullName: "catalog-1"}})).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SqlWarehouseRepository("sqlWarehouse1").Return(mockWarehouseRepo)
 
 	mockWarehouseRepo.EXPECT().GetTableInformation(mock.Anything, "catalog-1", "schema-1", "table-1").Return(map[string]*types2.ColumnInformation{
@@ -811,7 +825,7 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withFilters(t *testing.T) {
 			constants.DatabricksAccountId:     "AccountId",
 			constants.DatabricksUser:          "User",
 			constants.DatabricksPassword:      "Password",
-			constants.DatabricksSqlWarehouses: fmt.Sprintf(`{"metastore-id1": {"workspace": "%s", "warehouse": "sqlWarehouse1"}}`, deployment),
+			constants.DatabricksSqlWarehouses: fmt.Sprintf(`[{"workspace": "%s", "warehouse": "sqlWarehouse1"}]`, deployment),
 			constants.DatabricksPlatform:      "AWS",
 		},
 	}
@@ -834,6 +848,8 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withFilters(t *testing.T) {
 
 	mockWarehouseRepo := repo.NewMockWarehouseRepository(t)
 
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
+	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{{Name: "catalog-1", FullName: "catalog-1"}})).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SqlWarehouseRepository("sqlWarehouse1").Return(mockWarehouseRepo)
 	mockWorkspaceRepoMap[deployment].EXPECT().GetOwner(mock.Anything, catalog.SecurableTypeTable, "catalog-1.schema-1.table-1").Return("owner@raito.io", nil).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().GetOwner(mock.Anything, catalog.SecurableTypeTable, "catalog-1.schema-2.table-1").Return("owner2@raito.io", nil).Once()
@@ -953,7 +969,7 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withFilters_singleTable(t *test
 			constants.DatabricksAccountId:     "AccountId",
 			constants.DatabricksUser:          "User",
 			constants.DatabricksPassword:      "Password",
-			constants.DatabricksSqlWarehouses: fmt.Sprintf(`{"metastore-id1": {"workspace": "%s", "warehouse": "sqlWarehouse1"}}`, deployment),
+			constants.DatabricksSqlWarehouses: fmt.Sprintf(`[{"workspace": "%s", "warehouse": "sqlWarehouse1"}]`, deployment),
 			constants.DatabricksPlatform:      "AWS",
 		},
 	}
@@ -976,6 +992,8 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withFilters_singleTable(t *test
 
 	mockWarehouseRepo := repo.NewMockWarehouseRepository(t)
 
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
+	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{{Name: "catalog-1", FullName: "catalog-1"}})).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SqlWarehouseRepository("sqlWarehouse1").Return(mockWarehouseRepo)
 	mockWorkspaceRepoMap[deployment].EXPECT().GetOwner(mock.Anything, catalog.SecurableTypeTable, "catalog-1.schema-1.table-1").Return("owner@raito.io", nil).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SetPermissionsOnResource(mock.Anything, catalog.SecurableTypeFunction, "catalog-1.schema-1.raito_table-1_filter", catalog.PermissionsChange{Add: []catalog.Privilege{catalog.PrivilegeExecute}, Principal: "owner@raito.io"}).Return(nil)
@@ -1091,7 +1109,7 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withFilters_deletedFilter(t *te
 			constants.DatabricksAccountId:     "AccountId",
 			constants.DatabricksUser:          "User",
 			constants.DatabricksPassword:      "Password",
-			constants.DatabricksSqlWarehouses: fmt.Sprintf(`{"metastore-id1": {"workspace": "%s", "warehouse": "sqlWarehouse1"}}`, deployment),
+			constants.DatabricksSqlWarehouses: fmt.Sprintf(`[{"workspace": "%s", "warehouse": "sqlWarehouse1"}]`, deployment),
 			constants.DatabricksPlatform:      "AWS",
 		},
 	}
@@ -1114,6 +1132,8 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withFilters_deletedFilter(t *te
 
 	mockWarehouseRepo := repo.NewMockWarehouseRepository(t)
 
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
+	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{{Name: "catalog-1", FullName: "catalog-1"}})).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SqlWarehouseRepository("sqlWarehouse1").Return(mockWarehouseRepo)
 
 	mockWarehouseRepo.EXPECT().DropRowFilter(mock.Anything, "catalog-1", "schema-1", "table-1").Return(nil)
@@ -1239,7 +1259,19 @@ func TestAccessSyncer_SyncAccessProviderToTarget_withErrors(t *testing.T) {
 	mockAccountRepo.EXPECT().GetWorkspaces(mock.Anything).Return([]provisioning.Workspace{workspaceObject}, nil).Once()
 	mockAccountRepo.EXPECT().GetWorkspaceMap(mock.Anything, []catalog.MetastoreInfo{metastore1}, []provisioning.Workspace{workspaceObject}).Return(map[string][]*provisioning.Workspace{metastore1.MetastoreId: {{DeploymentName: deployment}}}, nil, nil).Once()
 
-	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Once()
+	mockWorkspaceRepoMap[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
+	mockWorkspaceRepoMap[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{
+		{
+			FullName:    "catalog-1",
+			MetastoreId: "catalogId-1",
+			Name:        "catalog-1",
+		},
+		{
+			FullName:    "catalog-2",
+			MetastoreId: "catalogId-2",
+			Name:        "catalog-2",
+		},
+	})).Once()
 	mockWorkspaceRepoMap[deployment].EXPECT().SetPermissionsOnResource(mock.Anything, catalog.SecurableTypeCatalog, "catalog-1", mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, securableType catalog.SecurableType, s string, change ...catalog.PermissionsChange) error {
 		assert.Len(t, change, 3)
 

--- a/databricks/data_object_traverser.go
+++ b/databricks/data_object_traverser.go
@@ -326,9 +326,13 @@ func (t *DataObjectTraverser) traverseAccount(ctx context.Context, accountRepo a
 
 	logger.Debug(fmt.Sprintf("Found %d workspaces", len(workspaces)))
 
+	outputWorkspaces := make([]provisioning.Workspace, 0, len(workspaces))
+
 	if options.SecurableTypesToReturn.Contains(constants.WorkspaceType) {
 		for i := range workspaces {
 			if t.shouldHandle(t.createFullName(constants.WorkspaceType, nil, &workspaces[i])) && t.workspaceFilter.IncludeObject(workspaces[i].WorkspaceName) {
+				outputWorkspaces = append(outputWorkspaces, workspaces[i])
+
 				err = visitor.VisitWorkspace(ctx, &workspaces[i])
 				if err != nil {
 					return nil, nil, err
@@ -336,6 +340,8 @@ func (t *DataObjectTraverser) traverseAccount(ctx context.Context, accountRepo a
 			}
 		}
 	}
+
+	workspaces = outputWorkspaces
 
 	metastoreWorkspaceMap, _, err := accountRepo.GetWorkspaceMap(ctx, metastores, workspaces)
 	if err != nil {

--- a/databricks/data_source.go
+++ b/databricks/data_source.go
@@ -82,8 +82,8 @@ func (d *DataSourceSyncer) SyncDataSource(ctx context.Context, dataSourceHandler
 
 	traverser, err := NewDataObjectTraverser(config, func() (accountRepository, error) {
 		return d.accountRepoFactory(pltfrm, accountId, &repoCredentials)
-	}, func(metastoreWorkspaces []*provisioning.Workspace) (workspaceRepository, *provisioning.Workspace, error) {
-		return utils.SelectWorkspaceRepo(ctx, repoCredentials, pltfrm, metastoreWorkspaces, d.workspaceRepoFactory)
+	}, func(metastoreWorkspace *provisioning.Workspace) (workspaceRepository, error) {
+		return utils.InitWorkspaceRepo(ctx, repoCredentials, pltfrm, metastoreWorkspace, d.workspaceRepoFactory)
 	}, createFullName)
 
 	if err != nil {
@@ -180,7 +180,7 @@ func (d DataSourceVisitor) VisitWorkspace(_ context.Context, workspace *provisio
 	})
 }
 
-func (d DataSourceVisitor) VisitMetastore(_ context.Context, metastore *catalog.MetastoreInfo, _ *provisioning.Workspace) error {
+func (d DataSourceVisitor) VisitMetastore(_ context.Context, metastore *catalog.MetastoreInfo, _ []*provisioning.Workspace) error {
 	logger.Info(fmt.Sprintf("Found metastore %q: %+v", metastore.Name, metastore))
 
 	return d.dataSourceHandler.AddDataObjects(&ds.DataObject{

--- a/databricks/data_source_tags_test.go
+++ b/databricks/data_source_tags_test.go
@@ -18,7 +18,6 @@ import (
 	"cli-plugin-databricks/databricks/constants"
 	"cli-plugin-databricks/databricks/repo"
 	"cli-plugin-databricks/databricks/repo/types"
-	types2 "cli-plugin-databricks/databricks/types"
 )
 
 func TestDataSourceTagHandler_LoadTags(t *testing.T) {
@@ -85,10 +84,7 @@ func TestDataSourceTagHandler_LoadTags(t *testing.T) {
 		tagCache:             make(map[string][]*tag.Tag),
 		configMap:            configMap,
 		workspaceRepoFactory: workspaceRepoFactory,
-		warehouseIdMap: map[string]types2.WarehouseDetails{"metastore1": {
-			Workspace: "workspaceId",
-			Warehouse: "warehouseId",
-		}},
+		warehouseIdMap:       map[string]string{"test-deployment": "warehouseId"},
 	}
 
 	// when
@@ -162,10 +158,7 @@ func TestDataSourceTagHandler_LoadTags_WarehouseNotDefined(t *testing.T) {
 		tagCache:             make(map[string][]*tag.Tag),
 		configMap:            configMap,
 		workspaceRepoFactory: workspaceRepoFactory,
-		warehouseIdMap: map[string]types2.WarehouseDetails{"another": {
-			Workspace: "workspaceId",
-			Warehouse: "warehouseId",
-		}},
+		warehouseIdMap:       map[string]string{"workspaceId": "warehouseId"},
 	}
 
 	// when

--- a/databricks/data_source_test.go
+++ b/databricks/data_source_test.go
@@ -74,7 +74,7 @@ func TestDataSourceSyncer_SyncDataSource(t *testing.T) {
 		},
 	}).Return(map[string][]*provisioning.Workspace{"metastore-Id1": {{DeploymentName: deployment}}}, nil, nil).Twice()
 
-	workspaceMocks[deployment].EXPECT().Ping(mock.Anything).Return(nil).Twice()
+	workspaceMocks[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
 	workspaceMocks[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{
 		{
 			Name:        "catalog-1",
@@ -198,7 +198,7 @@ func TestDataSourceSyncer_SyncDataSource_Partial(t *testing.T) {
 		},
 	}).Return(map[string][]*provisioning.Workspace{"metastore-Id1": {{DeploymentName: deployment}}}, nil, nil).Twice()
 
-	workspaceMocks[deployment].EXPECT().Ping(mock.Anything).Return(nil).Twice()
+	workspaceMocks[deployment].EXPECT().Ping(mock.Anything).Return(nil).Maybe()
 	workspaceMocks[deployment].EXPECT().ListCatalogs(mock.Anything).Return(repo.ArrayToChannel([]catalog.CatalogInfo{
 		{
 			Name:        "catalog-1",

--- a/databricks/utils/utils.go
+++ b/databricks/utils/utils.go
@@ -48,7 +48,7 @@ func InitializeWorkspaceRepoCredentials(repoCredentials repo.RepositoryCredentia
 		return nil, errors.New("unable to find workspace")
 	}
 
-	if pltfrm == platform.DatabricksPlatformAzure && workspace.AzureWorkspaceInfo != nil {
+	if pltfrm == platform.DatabricksPlatformAzure && workspace.AzureWorkspaceInfo != nil && repoCredentials.AzureClientId != "" {
 		repoCredentials.AzureResourceId = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Databricks/workspaces/%s", workspace.AzureWorkspaceInfo.SubscriptionId, workspace.AzureWorkspaceInfo.ResourceGroup, workspace.WorkspaceName)
 	} else {
 		host, err := pltfrm.WorkspaceAddress(workspace.DeploymentName)

--- a/databricks/utils/utils.go
+++ b/databricks/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
-	"github.com/hashicorp/go-multierror"
 	"github.com/raito-io/cli/base/util/config"
 	"github.com/raito-io/golang-set/set"
 
@@ -62,36 +61,23 @@ func InitializeWorkspaceRepoCredentials(repoCredentials repo.RepositoryCredentia
 	return &repoCredentials, nil
 }
 
-func SelectWorkspaceRepo[R workspaceRepo](ctx context.Context, repoCredentials repo.RepositoryCredentials, pltfrm platform.DatabricksPlatform, workspaces []*provisioning.Workspace, repoFn func(*repo.RepositoryCredentials) (R, error)) (R, *provisioning.Workspace, error) {
-	var err error
-
-	for _, workspace := range workspaces {
-		credentials, werr := InitializeWorkspaceRepoCredentials(repoCredentials, pltfrm, workspace)
-		if werr != nil {
-			err = multierror.Append(err, werr)
-			continue
-		}
-
-		repo, werr := repoFn(credentials)
-		if werr != nil {
-			err = multierror.Append(err, fmt.Errorf("generating repository for %q: %w", workspace.WorkspaceName, werr))
-			continue
-		}
-
-		werr = repo.Ping(ctx)
-		if werr != nil {
-			err = multierror.Append(err, fmt.Errorf("ping %q: %w", workspace.WorkspaceName, werr))
-			continue
-		}
-
-		return repo, workspace, nil
-	}
-
+func InitWorkspaceRepo[R workspaceRepo](ctx context.Context, repoCredentials repo.RepositoryCredentials, pltfrm platform.DatabricksPlatform, workspace *provisioning.Workspace, repoFn func(*repo.RepositoryCredentials) (R, error)) (R, error) {
 	var r R
 
-	if err == nil {
-		return r, nil, fmt.Errorf("no workspace found for metastore")
+	credentials, err := InitializeWorkspaceRepoCredentials(repoCredentials, pltfrm, workspace)
+	if err != nil {
+		return r, fmt.Errorf("load workspace credentials: %w", err)
 	}
 
-	return r, nil, fmt.Errorf("select workspace: %w", err)
+	repo, err := repoFn(credentials)
+	if err != nil {
+		return r, fmt.Errorf("generating repository for %q: %w", workspace.WorkspaceName, err)
+	}
+
+	err = repo.Ping(ctx)
+	if err != nil {
+		return r, fmt.Errorf("pinging workspace %q: %w", workspace.WorkspaceName, err)
+	}
+
+	return repo, nil
 }


### PR DESCRIPTION
We need to traverse over all workspaces to ensure we are able to sync all catalogs.
On top of that we need to ensure we can find which workspace to use when setting permissions in databricks.

Smaller fixes:
- Only provide AzureResourceID if we use AzureClientID (and entraID)
- Use workspace and metastore filters in data usage sync